### PR TITLE
Update bootstrap to 5.0.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6688,9 +6688,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-      "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -31765,9 +31765,9 @@
       }
     },
     "bootstrap": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
-      "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
       "dev": true,
       "requires": {}
     },


### PR DESCRIPTION
To fix the following warning that appears at build time

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacer, 4)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
253 │   1: $spacer / 4,
    │      ^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_variables.scss 253:6                                                                                                 @import
    node_modules/bootstrap/scss/bootstrap.scss 11:9                                                                                                   @import
    /var/folders/dw/6yt3gmbs19bdl3rffp6pv12h0000gn/T/broccoli-2433UmGV4ZQ2BDVR/out-313-broccoli_merge_trees_full_application/app/styles/app.scss 1:9  root stylesheet
```