### PR TITLE
Return HTTP status code on timeout

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -46,7 +46,6 @@ app.get('/*', async (req, res) => {
 
 app.use((err, req, res, next) => {
   if (req.timedout && !res.headerSent) {
-    console.log('TIMEOUT');
     res.status(503).json({ error: 'request timeout' });
   } else {
     if (err.code === 'ENOENT') {

--- a/index.mjs
+++ b/index.mjs
@@ -20,7 +20,6 @@ const router = createRouter(repositoryPath, adminPassword, pathPrefix);
 const app = express();
 
 if (timeoutMillisec > 0) {
-  console.log(`Enable timeout middleware(${timeoutMillisec} msec)`);
   app.use(timeout(timeoutMillisec));
 }
 
@@ -60,6 +59,12 @@ app.use((err, req, res, next) => {
   }
 });
 
-const server = app.listen(port, () => {
-  console.log(`listening on ${port}, repository is at ${repositoryPath}`);
+app.listen(port, () => {
+  const timeoutMessage = timeoutMillisec
+    ? `timeout in ${timeoutMillisec}ms`
+    : `no timeout`;
+
+  console.log(
+    `listening on ${port}, repository is at ${repositoryPath}, body size limit ${bodySizeLimit}, ${timeoutMessage}`
+  );
 });

--- a/index.mjs
+++ b/index.mjs
@@ -1,49 +1,49 @@
-import bodyParser from "body-parser";
-import express from "express";
-import morgan from "morgan";
-import path from "path";
-import url from "url";
+import bodyParser from 'body-parser';
+import express from 'express';
+import morgan from 'morgan';
+import path from 'path';
+import url from 'url';
 
-import createRouter from "./lib/create-router.mjs";
+import createRouter from './lib/create-router.mjs';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 const port = process.env.PORT || 3000;
-const repositoryPath = process.env.REPOSITORY_PATH || "./repository";
-const adminPassword = process.env.ADMIN_PASSWORD || "";
-const pathPrefix = process.env.ROOT_PATH || "/";
-const bodySizeLimit = process.env.BODY_SIZE_LIMIT || "10mb";
+const repositoryPath = process.env.REPOSITORY_PATH || './repository';
+const adminPassword = process.env.ADMIN_PASSWORD || '';
+const pathPrefix = process.env.ROOT_PATH || '/';
+const bodySizeLimit = process.env.BODY_SIZE_LIMIT || '10mb';
 const timeout = Number(process.env.SERVER_TIMEOUT || 0);
 const router = createRouter(repositoryPath, adminPassword, pathPrefix);
 
 const app = express();
 
-app.set("query parser", "extended");
-app.set("json spaces", 2);
+app.set('query parser', 'extended');
+app.set('json spaces', 2);
 
-if (process.env.NODE_ENV === "production") {
-  app.use(morgan("combined"));
+if (process.env.NODE_ENV === 'production') {
+  app.use(morgan('combined'));
 } else {
-  app.use(morgan("dev"));
+  app.use(morgan('dev'));
 }
 
 app.use(
-  bodyParser.json({ type: "application/vnd.api+json", limit: bodySizeLimit })
+  bodyParser.json({ type: 'application/vnd.api+json', limit: bodySizeLimit })
 );
 app.use(bodyParser.urlencoded({ extended: true, limit: bodySizeLimit }));
 
 app.use(pathPrefix, router);
-app.use(pathPrefix, express.static(__dirname + "/public"));
+app.use(pathPrefix, express.static(__dirname + '/public'));
 
-app.get("/*", async (req, res) => {
-  res.sendFile("index.html", { root: __dirname + "/public" });
+app.get('/*', async (req, res) => {
+  res.sendFile('index.html', { root: __dirname + '/public' });
 });
 
 app.use((err, req, res, next) => {
-  if (err.code === "ENOENT") {
+  if (err.code === 'ENOENT') {
     res.sendStatus(404);
   } else {
-    console.log("ERROR", err);
+    console.log('ERROR', err);
 
     res.status(422).json({ errors: [{ status: 500, detail: err.message }] });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "accepts": "^1.3.3",
         "body-parser": "^1.16.0",
         "commonmark": "^0.30.0",
+        "connect-timeout": "^1.9.0",
         "express": "^4.14.0",
         "express-promise-router": "^4.1.0",
         "fontoxpath": "^3.18.0",
@@ -3621,6 +3622,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/connect-timeout": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.9.0.tgz",
+      "integrity": "sha1-vCcyaxIhA3FL6/oNlYurM/ZSLjo=",
+      "dependencies": {
+        "http-errors": "~1.6.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect-timeout/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/connect-timeout/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/connect-timeout/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.3",
@@ -12614,6 +12653,40 @@
         "unique-string": "^2.0.0",
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
+      }
+    },
+    "connect-timeout": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.9.0.tgz",
+      "integrity": "sha1-vCcyaxIhA3FL6/oNlYurM/ZSLjo=",
+      "requires": {
+        "http-errors": "~1.6.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        }
       }
     },
     "content-disposition": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "accepts": "^1.3.3",
     "body-parser": "^1.16.0",
     "commonmark": "^0.30.0",
+    "connect-timeout": "^1.9.0",
     "express": "^4.14.0",
     "express-promise-router": "^4.1.0",
     "fontoxpath": "^3.18.0",


### PR DESCRIPTION
frontend 

<img width="1113" alt="スクリーンショット 2021-07-29 21 38 42" src="https://user-images.githubusercontent.com/3953/127495380-6aac589a-b8c1-438d-a2e1-c0b93d32dc2d.png">

server stdout

```
TIMEOUT
GET /trace/gene_and_organism_annotation?tax_id=9606&gene_id=BRCA1 503 104.298 ms - 32
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:561:11)
    at ServerResponse.header (/Users/tmaeda/src/github.com/dbcls/sparqlist/node_modules/express/lib/response.js:771:10)
    at file:///Users/tmaeda/src/github.com/dbcls/sparqlist/lib/create-router.mjs:140:11
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

raw response

```
$ curl -v 'http://localhost:3000/api/gene_and_organism_annotation?tax_id=9606&gene_id=BRCA1'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3000 (#0)
> GET /api/gene_and_organism_annotation?tax_id=9606&gene_id=BRCA1 HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 503 Service Unavailable
< X-Powered-By: Express
< Content-Type: application/json; charset=utf-8
< Content-Length: 32
< ETag: W/"20-MskKgUoWlumGzRlGAwKeEL7lQGs"
< Date: Thu, 29 Jul 2021 12:39:00 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
{
  "error": "request timeout"
* Connection #0 to host localhost left intact
}* Closing connection 0
```
